### PR TITLE
chore(*): reduce allocate bigInt

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -50,6 +50,8 @@ var (
 	NegativeOne = big.NewInt(-1)
 	Zero        = big.NewInt(0)
 	One         = big.NewInt(1)
+	Two         = big.NewInt(2)
+	BigInt128   = big.NewInt(128)
 
 	// used in liquidity amount math
 	Q96  = new(big.Int).Exp(big.NewInt(2), big.NewInt(96), nil)

--- a/entities/ticklist.go
+++ b/entities/ticklist.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"math"
 	"math/big"
+
+	"github.com/KyberNetwork/promm-sdk-go/constants"
 )
 
 const (
@@ -43,7 +45,7 @@ func ValidateList(ticks []Tick, tickSpacing int) error {
 	for _, tick := range ticks {
 		sum.Add(sum, tick.LiquidityNet)
 	}
-	if sum.Cmp(big.NewInt(0)) != 0 {
+	if sum.Cmp(constants.Zero) != 0 {
 		return ErrZeroNet
 	}
 

--- a/utils/encode.go
+++ b/utils/encode.go
@@ -11,6 +11,6 @@ import "math/big"
 func EncodeSqrtRatioX96(amount1 *big.Int, amount0 *big.Int) *big.Int {
 	numerator := new(big.Int).Lsh(amount1, 192)
 	denominator := amount0
-	ratioX192 := new(big.Int).Div(numerator, denominator)
-	return new(big.Int).Sqrt(ratioX192)
+	numerator.Div(numerator, denominator)
+	return numerator.Sqrt(numerator)
 }

--- a/utils/full_math.go
+++ b/utils/full_math.go
@@ -9,7 +9,7 @@ import (
 func MulDivRoundingUp(a, b, denominator *big.Int) *big.Int {
 	product := new(big.Int).Mul(a, b)
 	result := new(big.Int).Div(product, denominator)
-	if new(big.Int).Rem(product, denominator).Cmp(big.NewInt(0)) != 0 {
+	if new(big.Int).Rem(product, denominator).Cmp(constants.Zero) != 0 {
 		result.Add(result, constants.One)
 	}
 	return result
@@ -17,22 +17,19 @@ func MulDivRoundingUp(a, b, denominator *big.Int) *big.Int {
 
 func MulDivRoundingDown(a, b, denominator *big.Int) *big.Int {
 	product := new(big.Int).Mul(a, b)
-	result := new(big.Int).Quo(product, denominator)
-	return result
+	return product.Quo(product, denominator)
 }
 
 func MulDiv(a, b, denominator *big.Int) *big.Int {
 	product := new(big.Int).Mul(a, b)
-
-	return new(big.Int).Div(product, denominator)
+	return product.Div(product, denominator)
 }
 
 func GetSmallerRootOfQuadEqn(a, b, c *big.Int) *big.Int {
 	// smallerRoot = (b - sqrt(b * b - a * c)) / a;
 	tmp1 := new(big.Int).Mul(b, b)
 	tmp2 := new(big.Int).Mul(a, c)
-	tmp3 := new(big.Int).Sqrt(new(big.Int).Sub(tmp1, tmp2))
-	tmp4 := new(big.Int).Sub(b, tmp3)
-
-	return new(big.Int).Div(tmp4, a)
+	tmp3 := tmp1.Sqrt(tmp1.Sub(tmp1, tmp2))
+	tmp3.Sub(b, tmp3)
+	return tmp3.Div(tmp3, a)
 }

--- a/utils/max_liquidity_for_amounts.go
+++ b/utils/max_liquidity_for_amounts.go
@@ -21,8 +21,9 @@ func maxLiquidityForAmount0Imprecise(sqrtRatioAX96, sqrtRatioBX96, amount0 *big.
 	if sqrtRatioAX96.Cmp(sqrtRatioBX96) > 0 {
 		sqrtRatioAX96, sqrtRatioBX96 = sqrtRatioBX96, sqrtRatioAX96
 	}
-	intermediate := new(big.Int).Div(new(big.Int).Mul(sqrtRatioAX96, sqrtRatioBX96), constants.Q96)
-	return new(big.Int).Div(new(big.Int).Mul(amount0, intermediate), new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96))
+	temp := new(big.Int).Mul(sqrtRatioAX96, sqrtRatioBX96)
+	intermediate := temp.Div(temp, constants.Q96)
+	return new(big.Int).Div(intermediate.Mul(amount0, intermediate), new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96))
 }
 
 /**
@@ -37,8 +38,9 @@ func maxLiquidityForAmount0Precise(sqrtRatioAX96, sqrtRatioBX96, amount0 *big.In
 	if sqrtRatioAX96.Cmp(sqrtRatioBX96) > 0 {
 		sqrtRatioAX96, sqrtRatioBX96 = sqrtRatioBX96, sqrtRatioAX96
 	}
-	numerator := new(big.Int).Mul(new(big.Int).Mul(amount0, sqrtRatioAX96), sqrtRatioBX96)
-	denominator := new(big.Int).Mul(constants.Q96, new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96))
+	temp := new(big.Int).Mul(amount0, sqrtRatioAX96)
+	numerator := temp.Mul(temp, sqrtRatioBX96)
+	denominator := sqrtRatioBX96.Mul(constants.Q96, sqrtRatioBX96.Sub(sqrtRatioBX96, sqrtRatioAX96))
 	return new(big.Int).Div(numerator, denominator)
 }
 
@@ -53,7 +55,8 @@ func maxLiquidityForAmount1(sqrtRatioAX96, sqrtRatioBX96, amount1 *big.Int) *big
 	if sqrtRatioAX96.Cmp(sqrtRatioBX96) > 0 {
 		sqrtRatioAX96, sqrtRatioBX96 = sqrtRatioBX96, sqrtRatioAX96
 	}
-	return new(big.Int).Div(new(big.Int).Mul(amount1, constants.Q96), new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96))
+	temp := new(big.Int).Mul(amount1, constants.Q96)
+	return temp.Div(temp, new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96))
 }
 
 /**

--- a/utils/most_significant_bit.go
+++ b/utils/most_significant_bit.go
@@ -10,6 +10,14 @@ import (
 )
 
 var ErrInvalidInput = errors.New("invalid input")
+var powers = []int64{128, 64, 32, 16, 8, 4, 2, 1}
+var powerBigInts = make([]*big.Int, len(powers))
+
+func init() {
+	for i := range powers {
+		powerBigInts[i] = big.NewInt(powers[i])
+	}
+}
 
 func MostSignificantBit(x *big.Int) (int64, error) {
 	if x.Cmp(constants.Zero) <= 0 {
@@ -19,8 +27,8 @@ func MostSignificantBit(x *big.Int) (int64, error) {
 		return 0, ErrInvalidInput
 	}
 	var msb int64
-	for _, power := range []int64{128, 64, 32, 16, 8, 4, 2, 1} {
-		min := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(power)), nil)
+	for i, power := range powers {
+		min := new(big.Int).Exp(constants.Two, powerBigInts[i], nil)
 		if x.Cmp(min) >= 0 {
 			x = new(big.Int).Rsh(x, uint(power))
 			msb += power

--- a/utils/sqrtprice_math.go
+++ b/utils/sqrtprice_math.go
@@ -14,16 +14,16 @@ var (
 	ErrLiquidityLessThanZero = errors.New("liquidity less than zero")
 	ErrInvariant             = errors.New("invariant violation")
 )
-var MaxUint160 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(160), nil), constants.One)
+var MaxUint160 = new(big.Int).Sub(new(big.Int).Exp(constants.Two, big.NewInt(160), nil), constants.One)
 
 func multiplyIn256(x, y *big.Int) *big.Int {
 	product := new(big.Int).Mul(x, y)
-	return new(big.Int).And(product, entities.MaxUint256)
+	return product.And(product, entities.MaxUint256)
 }
 
 func addIn256(x, y *big.Int) *big.Int {
 	sum := new(big.Int).Add(x, y)
-	return new(big.Int).And(sum, entities.MaxUint256)
+	return sum.And(sum, entities.MaxUint256)
 }
 
 func GetAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp bool) *big.Int {
@@ -37,7 +37,8 @@ func GetAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp b
 	if roundUp {
 		return MulDivRoundingUp(MulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96), constants.One, sqrtRatioAX96)
 	}
-	return new(big.Int).Div(new(big.Int).Div(new(big.Int).Mul(numerator1, numerator2), sqrtRatioBX96), sqrtRatioAX96)
+	numerator1.Mul(numerator1, numerator2)
+	return numerator1.Div(numerator1.Div(numerator1, sqrtRatioBX96), sqrtRatioAX96)
 }
 
 func GetAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp bool) *big.Int {
@@ -48,7 +49,8 @@ func GetAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp b
 	if roundUp {
 		return MulDivRoundingUp(liquidity, new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96), constants.Q96)
 	}
-	return new(big.Int).Div(new(big.Int).Mul(liquidity, new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96)), constants.Q96)
+	temp := new(big.Int).Sub(sqrtRatioBX96, sqrtRatioAX96)
+	return temp.Div(temp.Mul(liquidity, temp), constants.Q96)
 }
 
 func GetNextSqrtPriceFromInput(sqrtPX96, liquidity, amountIn *big.Int, zeroForOne bool) (*big.Int, error) {
@@ -100,7 +102,7 @@ func getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amount *big.Int,
 		if numerator1.Cmp(product) <= 0 {
 			return nil, ErrInvariant
 		}
-		denominator := new(big.Int).Sub(numerator1, product)
+		denominator := product.Sub(numerator1, product)
 		return MulDivRoundingUp(numerator1, sqrtPX96, denominator), nil
 	}
 }

--- a/utils/swap_math.go
+++ b/utils/swap_math.go
@@ -32,6 +32,7 @@ func ComputeSwapStep(
 		sqrtRatioNextX96 = sqrtRatioTargetX96
 	}
 
+	// ??? not use
 	amountIn = usedAmount
 
 	var absUsedAmount *big.Int
@@ -81,11 +82,12 @@ func calcReachAmount(
 			// numerator = 2 * liquidity * absPriceDiff
 			// denominator = currentSqrtP * (2 * targetSqrtP - currentSqrtP * feeInFeeUnits / FEE_UNITS)
 			// overflow should not happen because the absPriceDiff is capped to ~5%
+			temp := new(big.Int).Mul(TwoFeeUnits, sqrtRatioTargetX96)
 			denominator := new(big.Int).Sub(
-				new(big.Int).Mul(TwoFeeUnits, sqrtRatioTargetX96),
+				temp,
 				new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioCurrentX96),
 			)
-			numerator := MulDiv(liquidity, new(big.Int).Mul(TwoFeeUnits, absPriceDiff), denominator)
+			numerator := MulDiv(liquidity, temp.Mul(TwoFeeUnits, absPriceDiff), denominator)
 
 			reachAmount = MulDiv(numerator, constants.Q96, sqrtRatioCurrentX96)
 		} else {
@@ -93,11 +95,13 @@ func calcReachAmount(
 			// numerator: liquidity * absPriceDiff * (TWO_FEE_UNITS * targetSqrtP - feeInFeeUnits * (targetSqrtP + currentSqrtP))
 			// denominator: (TWO_FEE_UNITS * targetSqrtP - feeInFeeUnits * currentSqrtP)
 			// overflow should not happen because the absPriceDiff is capped to ~5%
+			temp := new(big.Int).Mul(TwoFeeUnits, sqrtRatioCurrentX96)
+
 			denominator := new(big.Int).Sub(
-				new(big.Int).Mul(TwoFeeUnits, sqrtRatioCurrentX96),
+				temp,
 				new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioTargetX96),
 			)
-			numerator := MulDiv(liquidity, new(big.Int).Mul(TwoFeeUnits, absPriceDiff), denominator)
+			numerator := MulDiv(liquidity, temp.Mul(TwoFeeUnits, absPriceDiff), denominator)
 
 			reachAmount = MulDiv(numerator, sqrtRatioCurrentX96, constants.Q96)
 		}
@@ -109,33 +113,38 @@ func calcReachAmount(
 			// numerator: (liquidity)(absPriceDiff)(2 * currentSqrtP - deltaL * (currentSqrtP + targetSqrtP))
 			// denominator: (currentSqrtP * targetSqrtP) * (2 * currentSqrtP - deltaL * targetSqrtP)
 			// overflow should not happen because the absPriceDiff is capped to ~5%
+
+			temp := new(big.Int).Mul(TwoFeeUnits, sqrtRatioCurrentX96)
+
 			denominator := new(big.Int).Sub(
-				new(big.Int).Mul(TwoFeeUnits, sqrtRatioCurrentX96),
+				temp,
 				new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioTargetX96),
 			)
 			numerator := new(big.Int).Sub(
-				denominator, new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioCurrentX96),
+				denominator, temp.Mul(big.NewInt(int64(feeInUnits)), sqrtRatioCurrentX96),
 			)
-			numerator = MulDiv(new(big.Int).Lsh(liquidity, 96), numerator, denominator)
+			numerator = MulDiv(temp.Lsh(liquidity, 96), numerator, denominator)
 
 			reachAmount = new(big.Int).Div(MulDiv(numerator, absPriceDiff, sqrtRatioCurrentX96), sqrtRatioTargetX96)
-			reachAmount = new(big.Int).Mul(reachAmount, constants.NegativeOne)
+			reachAmount = temp.Mul(reachAmount, constants.NegativeOne)
 		} else {
 			// exactOut + swap 1 -> 0
 			// numerator: liquidity * absPriceDiff * (TWO_FEE_UNITS * targetSqrtP - feeInFeeUnits * (targetSqrtP + currentSqrtP))
 			// denominator: (TWO_FEE_UNITS * targetSqrtP - feeInFeeUnits * currentSqrtP)
 			// overflow should not happen because the absPriceDiff is capped to ~5%
+			temp := new(big.Int).Mul(TwoFeeUnits, sqrtRatioTargetX96)
+
 			denominator := new(big.Int).Sub(
-				new(big.Int).Mul(TwoFeeUnits, sqrtRatioTargetX96),
+				temp,
 				new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioCurrentX96),
 			)
 			numerator := new(big.Int).Sub(
-				denominator, new(big.Int).Mul(big.NewInt(int64(feeInUnits)), sqrtRatioTargetX96),
+				denominator, temp.Mul(big.NewInt(int64(feeInUnits)), sqrtRatioTargetX96),
 			)
 			numerator = MulDiv(liquidity, numerator, denominator)
 
 			reachAmount = MulDiv(numerator, absPriceDiff, constants.Q96)
-			reachAmount = new(big.Int).Mul(reachAmount, constants.NegativeOne)
+			reachAmount = temp.Mul(reachAmount, constants.NegativeOne)
 		}
 	}
 
@@ -172,8 +181,9 @@ func calcReturnedAmount(
 		// returnedAmount = (liquidity + deltaL)/nextSqrtP - (liquidity)/currentSqrtP
 		// if exactInput, minimise actual output (<0, make less negative) so we avoid sending too much
 		// if exactOutput, maximise actual input (>0) so we get desired output amount
-		returnedAmount = new(big.Int).Add(
-			MulDivRoundingUp(new(big.Int).Add(liquidity, deltaL), constants.Q96, sqrtRatioTargetX96),
+		temp := new(big.Int).Add(liquidity, deltaL)
+		returnedAmount = temp.Add(
+			MulDivRoundingUp(temp, constants.Q96, sqrtRatioTargetX96),
 			new(big.Int).Mul(MulDivRoundingUp(liquidity, constants.Q96, sqrtRatioCurrentX96), constants.NegativeOne),
 		)
 	}
@@ -191,44 +201,43 @@ func calcReturnedAmount(
 func calcIncrementalLiquidity(
 	sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, absAmount *big.Int, exactIn, isToken0 bool,
 ) (deltaL *big.Int) {
-	var tmp1, tmp2, tmp3 *big.Int
 
 	// this is when we reach the target, then we have target_X96
 	if isToken0 {
 		// deltaL = nextSqrtP * (liquidity / currentSqrtP +/- absDelta)) - liquidity
 		// needs to be minimum
-		tmp1 = MulDiv(liquidity, constants.Q96, sqrtRatioCurrentX96)
+		tmp := MulDiv(liquidity, constants.Q96, sqrtRatioCurrentX96)
 		if exactIn {
-			tmp2 = new(big.Int).Add(tmp1, absAmount)
+			tmp.Add(tmp, absAmount)
 		} else {
-			tmp2 = new(big.Int).Sub(tmp1, absAmount)
+			tmp.Sub(tmp, absAmount)
 		}
-		tmp3 = MulDiv(sqrtRatioTargetX96, tmp2, constants.Q96)
+		tmp = MulDiv(sqrtRatioTargetX96, tmp, constants.Q96)
 
 		// in edge cases where liquidity or absDelta is small
 		// liquidity might be greater than nextSqrtP * ((liquidity / currentSqrtP) +/- absDelta))
 		// due to rounding
-		if tmp3.Cmp(liquidity) > 0 {
-			deltaL = new(big.Int).Sub(tmp3, liquidity)
+		if tmp.Cmp(liquidity) > 0 {
+			deltaL = tmp.Sub(tmp, liquidity)
 		} else {
 			deltaL = constants.Zero
 		}
 	} else {
 		// deltaL = (liquidity * currentSqrtP +/- absDelta) / nextSqrtP - liquidity
 		// needs to be minimum
-		tmp1 = MulDiv(liquidity, sqrtRatioCurrentX96, constants.Q96)
+		tmp := MulDiv(liquidity, sqrtRatioCurrentX96, constants.Q96)
 		if exactIn {
-			tmp2 = new(big.Int).Add(tmp1, absAmount)
+			tmp.Add(tmp, absAmount)
 		} else {
-			tmp2 = new(big.Int).Sub(tmp1, absAmount)
+			tmp.Sub(tmp, absAmount)
 		}
-		tmp3 = MulDiv(tmp2, constants.Q96, sqrtRatioTargetX96)
+		tmp = MulDiv(tmp, constants.Q96, sqrtRatioTargetX96)
 
 		// in edge cases where liquidity or absDelta is small
 		// liquidity might be greater than nextSqrtP * ((liquidity / currentSqrtP) +/- absDelta))
 		// due to rounding
-		if tmp3.Cmp(liquidity) > 0 {
-			deltaL = new(big.Int).Sub(tmp3, liquidity)
+		if tmp.Cmp(liquidity) > 0 {
+			deltaL = tmp.Sub(tmp, liquidity)
 		} else {
 			deltaL = constants.Zero
 		}
@@ -261,21 +270,22 @@ func estimateIncrementalLiquidity(
 	} else {
 		// obtain the smaller root of the quadratic equation
 		// ax^2 - 2bx + c = 0 such that b > 0, and x denotes deltaL
+		tmp := new(big.Int).Sub(FeeUnits, fee)
 		a := fee
-		b := new(big.Int).Mul(new(big.Int).Sub(FeeUnits, fee), liquidity)
-		c := new(big.Int).Mul(new(big.Int).Mul(fee, liquidity), absAmount)
+		b := new(big.Int).Mul(tmp, liquidity)
+		c := new(big.Int).Mul(tmp.Mul(fee, liquidity), absAmount)
 
 		if isToken0 {
 			// a = feeInFeeUnits
 			// b = (FEE_UNITS - feeInFeeUnits) * liquidity - FEE_UNITS * absDelta * currentSqrtP
 			// c = feeInFeeUnits * liquidity * absDelta * currentSqrtP
-			b = new(big.Int).Sub(b, MulDiv(new(big.Int).Mul(FeeUnits, absAmount), sqrtRatioCurrentX96, constants.Q96))
+			b = tmp.Sub(b, MulDiv(tmp.Mul(FeeUnits, absAmount), sqrtRatioCurrentX96, constants.Q96))
 			c = MulDiv(c, sqrtRatioCurrentX96, constants.Q96)
 		} else {
 			// a = feeInFeeUnits
 			// b = (FEE_UNITS - feeInFeeUnits) * liquidity - FEE_UNITS * absDelta / currentSqrtP
 			// c = liquidity * feeInFeeUnits * absDelta / currentSqrtP
-			b = new(big.Int).Sub(b, MulDiv(new(big.Int).Mul(FeeUnits, absAmount), constants.Q96, sqrtRatioCurrentX96))
+			b = tmp.Sub(b, MulDiv(tmp.Mul(FeeUnits, absAmount), constants.Q96, sqrtRatioCurrentX96))
 			c = MulDiv(c, constants.Q96, sqrtRatioCurrentX96)
 		}
 
@@ -291,8 +301,6 @@ func estimateIncrementalLiquidity(
 func calcFinalPrice(
 	absAmount, liquidity, deltaL, sqrtRatioCurrentX96 *big.Int, exactIn, isToken0 bool,
 ) (returnAmount *big.Int) {
-	returnAmount = constants.Zero
-
 	if isToken0 {
 		tmp := MulDiv(absAmount, sqrtRatioCurrentX96, constants.Q96)
 
@@ -300,13 +308,13 @@ func calcFinalPrice(
 			// minimise actual output (<0, make less negative) so we avoid sending too much
 			// returnedAmount = deltaL * nextSqrtP - liquidity * (currentSqrtP - nextSqrtP)
 			returnAmount = MulDivRoundingUp(
-				new(big.Int).Add(liquidity, deltaL), sqrtRatioCurrentX96, new(big.Int).Add(liquidity, tmp),
+				new(big.Int).Add(liquidity, deltaL), sqrtRatioCurrentX96, tmp.Add(liquidity, tmp),
 			)
 		} else {
 			// maximise actual input (>0) so we get desired output amount
 			// returnedAmount = deltaL * nextSqrtP + liquidity * (nextSqrtP - currentSqrtP)
 			returnAmount = MulDiv(
-				new(big.Int).Add(liquidity, deltaL), sqrtRatioCurrentX96, new(big.Int).Sub(liquidity, tmp),
+				new(big.Int).Add(liquidity, deltaL), sqrtRatioCurrentX96, tmp.Sub(liquidity, tmp),
 			)
 		}
 	} else {
@@ -317,11 +325,11 @@ func calcFinalPrice(
 
 		if exactIn {
 			returnAmount = MulDiv(
-				new(big.Int).Add(liquidity, tmp), sqrtRatioCurrentX96, new(big.Int).Add(liquidity, deltaL),
+				tmp.Add(liquidity, tmp), sqrtRatioCurrentX96, new(big.Int).Add(liquidity, deltaL),
 			)
 		} else {
 			returnAmount = MulDivRoundingUp(
-				new(big.Int).Sub(liquidity, tmp), sqrtRatioCurrentX96, new(big.Int).Add(liquidity, deltaL),
+				tmp.Sub(liquidity, tmp), sqrtRatioCurrentX96, new(big.Int).Add(liquidity, deltaL),
 			)
 		}
 	}

--- a/utils/tick_math.go
+++ b/utils/tick_math.go
@@ -26,8 +26,8 @@ var (
 )
 
 func mulShift(val *big.Int, mulBy *big.Int) *big.Int {
-
-	return new(big.Int).Rsh(new(big.Int).Mul(val, mulBy), 128)
+	temp := new(big.Int).Mul(val, mulBy)
+	return temp.Rsh(temp, 128)
 }
 
 var (
@@ -162,25 +162,27 @@ func GetTickAtSqrtRatio(sqrtRatioX96 *big.Int) (int, error) {
 		return 0, err
 	}
 	var r *big.Int
-	if big.NewInt(msb).Cmp(big.NewInt(128)) >= 0 {
-		r = new(big.Int).Rsh(sqrtRatioX128, uint(msb-127))
+	if big.NewInt(msb).Cmp(constants.BigInt128) >= 0 {
+		r = sqrtRatioX128.Rsh(sqrtRatioX128, uint(msb-127))
 	} else {
-		r = new(big.Int).Lsh(sqrtRatioX128, uint(127-msb))
+		r = sqrtRatioX128.Lsh(sqrtRatioX128, uint(127-msb))
 	}
-
-	log2 := new(big.Int).Lsh(new(big.Int).Sub(big.NewInt(msb), big.NewInt(128)), 64)
+	msbBigInt := big.NewInt(msb)
+	msbBigInt.Sub(msbBigInt, constants.BigInt128)
+	log2 := msbBigInt.Lsh(msbBigInt, 64)
 
 	for i := 0; i < 14; i++ {
-		r = new(big.Int).Rsh(new(big.Int).Mul(r, r), 127)
+		r.Rsh(r.Mul(r, r), 127)
 		f := new(big.Int).Rsh(r, 128)
 		log2 = new(big.Int).Or(log2, new(big.Int).Lsh(f, uint(63-i)))
-		r = new(big.Int).Rsh(r, uint(f.Int64()))
+		r.Rsh(r, uint(f.Int64()))
 	}
 
-	logSqrt10001 := new(big.Int).Mul(log2, magicSqrt10001)
-
-	tickLow := new(big.Int).Rsh(new(big.Int).Sub(logSqrt10001, magicTickLow), 128).Int64()
-	tickHigh := new(big.Int).Rsh(new(big.Int).Add(logSqrt10001, magicTickHigh), 128).Int64()
+	logSqrt10001 := log2.Mul(log2, magicSqrt10001)
+	temp := new(big.Int).Sub(logSqrt10001, magicTickLow)
+	tickLow := temp.Rsh(temp, 128).Int64()
+	temp = temp.Add(logSqrt10001, magicTickHigh)
+	tickHigh := temp.Rsh(temp, 128).Int64()
 
 	if tickLow == tickHigh {
 		return int(tickLow), nil

--- a/utils/tick_math_test.go
+++ b/utils/tick_math_test.go
@@ -31,5 +31,5 @@ func TestGetTickAtSqrtRatio(t *testing.T) {
 	assert.Equal(t, tmin, MinTick, "returns the correct value for sqrt ratio at min tick")
 
 	tmax, _ := GetTickAtSqrtRatio(new(big.Int).Sub(MaxSqrtRatio, constants.One))
-	assert.Equal(t, tmax, MaxTick-1, "returns the correct value for sqrt ratio at max tick")
+	assert.Equal(t, MaxTick-1, tmax, "returns the correct value for sqrt ratio at max tick")
 }


### PR DESCRIPTION
### Why did we need it?
- Reduce allocate Big.Int